### PR TITLE
fix events & jobs section layout shift

### DIFF
--- a/app/events/event.tsx
+++ b/app/events/event.tsx
@@ -7,6 +7,7 @@ import Banner from "../components/banner/banner";
 
 export default function Event() {
   const [data, setData] = useState([]);
+  const [loader, setLoader] = useState(true);
 
   useEffect(() => {
     axios
@@ -29,7 +30,8 @@ export default function Event() {
       })
       .catch(function (error) {
         console.log(error);
-      });
+      })
+      .finally(() => setLoader(false));
   }, []);
   return (
     <div className="flex flex-col items-center justify-center gap-4 mt-6">
@@ -78,11 +80,10 @@ export default function Event() {
         </div>
       )}
       {/* <Banner /> */}
-      {data === undefined && (
-        <h1 className="py-12 text-2xl text-center">
-          Sorry 🥺 there are no upcoming events
-        </h1>
-      )}
+      <div className="py-12 text-2xl text-center">
+        {loader && <h1>Loading ✨</h1>}
+        {data === undefined && <h1>Sorry 🥺 there are no upcoming events</h1>}
+      </div>
       <p className="text-base text-center">
         Powered by{" "}
         <a

--- a/app/jobs/jobs.tsx
+++ b/app/jobs/jobs.tsx
@@ -1,6 +1,6 @@
 "use client";
 import axios from "axios";
-import { useEffect, useState, useRef } from "react";
+import { useEffect, useState, useRef, useLayoutEffect } from "react";
 import Image from "next/image";
 import moment from "moment";
 import "react-tooltip/dist/react-tooltip.css";
@@ -9,6 +9,7 @@ import { Tooltip } from "react-tooltip";
 export default function Jobs() {
   const [jobs, setJobs] = useState([]);
   const [size, setSize] = useState(16);
+  const [loader, setLoader] = useState(true);
 
   const [count, setCount] = useState(0);
 
@@ -16,7 +17,7 @@ export default function Jobs() {
     setSize(size + 16);
   }
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     axios
       .get(`https://api.social3.club/job/get?page=1&size=${size}`, {
         headers: {
@@ -30,7 +31,8 @@ export default function Jobs() {
       .catch(function (error) {
         console.log(error);
         setJobs([]);
-      });
+      })
+      .finally(() => setLoader(false));
   }, [size]);
   return (
     <>
@@ -115,11 +117,13 @@ export default function Jobs() {
             );
           })}
         </div>
-        {jobs.length <= 0 && (
-          <h1 className="pt-12 pb-20 text-2xl text-center">
-            Sorry 🥺 there are no jobs to show
-          </h1>
-        )}
+
+        <div className="pt-12 pb-20 text-2xl text-center">
+          {loader && <h1>Loading 🪄</h1>}
+          {jobs.length <= 0 && !loader && (
+            <h1>Sorry 🥺 there are no jobs to show</h1>
+          )}
+        </div>
 
         {jobs.length !== count && (
           <button


### PR DESCRIPTION
Layout is being shifted while loading the jobs section and events section , added a loading text to prevent that behavior.